### PR TITLE
Fix: Update title to remove abbreviations and add data timestamp

### DIFF
--- a/data_flow.mmd
+++ b/data_flow.mmd
@@ -1,4 +1,5 @@
 graph TD
+    subgraph Backend
     A[GitHub Actions Trigger] --> B(Pulse Check Python Script)
     B --> C[Read All Existing CSV Data]
     C --> D[Fetch Latest BoC API Data]
@@ -7,12 +8,14 @@ graph TD
     F --> G[Sort All Data by Date - Ascending]
     G --> H[Rewrite CSV File]
     H --> I[Commit & Push Changes]
-    
-    subgraph Logic Improvements
-    G
-    H
     end
-    
-    subgraph Storage
-    H
+
+    subgraph Frontend
+    J[User Opens index.html] --> K[PapaParse Reads CSV]
+    K --> L[Filter Valid Rows]
+    L --> M[Extract Last Entry Date]
+    M --> N[Update last-updated Span]
+    L --> O[Render Charts]
     end
+
+    I -.-> K

--- a/docs/index.html
+++ b/docs/index.html
@@ -89,7 +89,7 @@
 <header>
     <div class="header-content">
         <h1>Canadian Government Bond Yield Analysis</h1>
-        <p>2Y vs 5Y Benchmark Bonds & Historical Spread | Data current as of 2026-03-22 02:01:52</p>
+        <p>2Y vs 5Y Benchmark Bonds & Historical Spread | Data current as of <span id="last-updated">...</span></p>
     </div>
     <div class="controls">
         <button class="btn active" onclick="updateRange(30, this)">30D</button>
@@ -125,6 +125,13 @@
         dynamicTyping: true,
         complete: function(results) {
             rawData = results.data.filter(row => row.date);
+            
+            // Set the "last updated" date from the final entry in the CSV
+            if (rawData.length > 0) {
+                const lastEntry = rawData[rawData.length - 1];
+                document.getElementById('last-updated').textContent = lastEntry.date;
+            }
+
             // Default to 30 days
             updateRange(30);
         }


### PR DESCRIPTION
This PR fixes #1 by updating the title to 'Canadian Government Bond Yield Analysis' and adding a subtitle with the current timestamp.