### PR TITLE
feat: Add Lending Margin chart to dashboard

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -83,6 +83,19 @@
             height: 400px;
         }
 
+        .disclaimer {
+            width: 100%;
+            max-width: 1200px;
+            box-sizing: border-box;
+            color: #ffbd2e;
+            font-size: 0.85rem;
+            padding: 12px 15px;
+            border-left: 4px solid #ff4500;
+            background: rgba(30, 35, 41, 0.8);
+            border-radius: 4px;
+            margin-bottom: -15px;
+        }
+
         canvas { width: 100% !important; height: 100% !important; }
         
         footer {
@@ -121,7 +134,7 @@
     </div>
 
     <!-- Data Disclaimer -->
-    <div style="width: 100%; max-width: 1200px; color: #ffbd2e; font-size: 0.85rem; padding: 12px 15px; border-left: 4px solid #ff4500; background: rgba(30, 35, 41, 0.8); border-radius: 4px; margin-bottom: -15px;">
+    <div class="disclaimer">
         <strong>⚠️ Market Data Notice:</strong> Mortgage rates are estimated based on representative insured products. Daily fluctuations, data provider delays, or automated collection anomalies may result in temporary inaccuracies. This dashboard is for informational purposes only.
     </div>
 


### PR DESCRIPTION
Added a third chart to the dashboard titled 'Lending Margin'. 

Key features:
- Plots **Lending Margin** (Mortgage Rate - 5Y Bond Yield) in a distinct thick green line.
- Overlays **Best 5Y Fixed Rate** (dashed orange) and **CAN 5Y Bond Yield** (dashed blue) for context.
- Added a footer with a 'Last Updated' timestamp in Mountain Time.
- Ensured all charts share the same timescales and interactive controls.
- Improved SMA calculation robustness.