### PR TITLE
Fix: Rate Hub API Limit Check (#17)

### DIFF
--- a/pulse_check.py
+++ b/pulse_check.py
@@ -95,7 +95,8 @@ def update_dashboard_data():
 
         # 2. Check if we already have complete data for the latest observation date
         # This acts as a rate-limiting mechanism for the Ratehub API.
-        latest_date = observations[-1]['d']
+        # BoC API may return observations in descending order. Use max() for safety.
+        latest_date = max(obs['d'] for obs in observations)
         all_rows = get_all_rows(CSV_FILE)
         existing_data = {row['date']: row for row in all_rows}
         
@@ -104,7 +105,7 @@ def update_dashboard_data():
         
         # If the latest date exists and already has mortgage data, skip Ratehub API call
         if latest_row and latest_row.get('mortgage_5y') is not None:
-            print(f"✨ Data for {latest_date} is already complete in CSV. Skipping Ratehub API call.")
+            print(f"✨ Latest observation date {latest_date} already has mortgage data in CSV. Skipping Ratehub API call.")
             best_mortgage = latest_row['mortgage_5y']
         else:
             # Fetch latest mortgage rate only if needed

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,6 +1,8 @@
 import pytest
 import requests_mock
-from pulse_check import get_best_5y_fixed, RATEHUB_URL
+import os
+import csv
+from pulse_check import get_best_5y_fixed, update_dashboard_data, SERIES_2Y, SERIES_5Y, RATEHUB_URL
 
 def test_get_best_5y_fixed_success():
     """
@@ -118,3 +120,95 @@ def test_get_best_5y_fixed_api_error():
         m.get(RATEHUB_URL, status_code=500)
         rate = get_best_5y_fixed()
         assert rate is None
+
+def test_update_dashboard_data_rate_limit(tmp_path):
+    """
+    Test that Ratehub API is skipped if the latest BoC date already has mortgage data.
+    """
+    # Create a temporary CSV file
+    csv_file = tmp_path / "test_spread.csv"
+    import pulse_check
+    pulse_check.CSV_FILE = str(csv_file)
+    
+    # Pre-populate CSV with "complete" data for the latest date
+    with open(csv_file, mode='w', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(f, fieldnames=['date', 'yield_2y', 'yield_5y', 'spread', 'mortgage_5y', 'lending_margin'])
+        writer.writeheader()
+        writer.writerow({
+            'date': '2026-03-25',
+            'yield_2y': 2.5,
+            'yield_5y': 3.0,
+            'spread': 0.5,
+            'mortgage_5y': 4.0,
+            'lending_margin': 1.0
+        })
+
+    # Mock BoC API to return observations (descending order)
+    boc_url = f"https://www.bankofcanada.ca/valet/observations/{SERIES_2Y}%2C{SERIES_5Y}/json?recent=10"
+    mock_boc_data = {
+        "observations": [
+            {"d": "2026-03-25", SERIES_2Y: {"v": "2.5"}, SERIES_5Y: {"v": "3.0"}},
+            {"d": "2026-03-24", SERIES_2Y: {"v": "2.4"}, SERIES_5Y: {"v": "2.9"}}
+        ]
+    }
+
+    with requests_mock.Mocker() as m:
+        m.get(boc_url, json=mock_boc_data)
+        # RATEHUB_URL is NOT mocked, so it will error if called.
+        
+        update_dashboard_data()
+        
+        with open(csv_file, mode='r', newline='', encoding='utf-8') as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+            assert len(rows) == 2
+            assert rows[1]['date'] == '2026-03-25'
+            assert rows[1]['mortgage_5y'] == '4.0'
+
+def test_update_dashboard_data_no_rate_limit(tmp_path):
+    """
+    Test that Ratehub API IS called if the latest BoC date is missing mortgage data.
+    """
+    csv_file = tmp_path / "test_spread_no_limit.csv"
+    import pulse_check
+    pulse_check.CSV_FILE = str(csv_file)
+    
+    with open(csv_file, mode='w', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(f, fieldnames=['date', 'yield_2y', 'yield_5y', 'spread', 'mortgage_5y', 'lending_margin'])
+        writer.writeheader()
+        writer.writerow({
+            'date': '2026-03-25',
+            'yield_2y': 2.5,
+            'yield_5y': 3.0,
+            'spread': 0.5,
+            'mortgage_5y': '', # Missing
+            'lending_margin': ''
+        })
+
+    boc_url = f"https://www.bankofcanada.ca/valet/observations/{SERIES_2Y}%2C{SERIES_5Y}/json?recent=10"
+    mock_boc_data = {
+        "observations": [
+            {"d": "2026-03-25", SERIES_2Y: {"v": "2.5"}, SERIES_5Y: {"v": "3.0"}}
+        ]
+    }
+    
+    mock_ratehub_data = {
+        "data": {
+            "rates": [
+                {"value": 3.99, "description": "5-yr Fixed", "insuranceBucket": "insured"}
+            ]
+        }
+    }
+
+    with requests_mock.Mocker() as m:
+        m.get(boc_url, json=mock_boc_data)
+        m.get(RATEHUB_URL, json=mock_ratehub_data)
+        
+        update_dashboard_data()
+        
+        assert m.call_count == 2
+        
+        with open(csv_file, mode='r', newline='', encoding='utf-8') as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+            assert rows[0]['mortgage_5y'] == '3.99'


### PR DESCRIPTION
This PR fixes the issue where the Ratehub API limit check was using the oldest observation date from BoC instead of the newest. This caused unnecessary skips and inconsistent data updates.

Changes:
- Corrected pulse_check.py to use the most recent observation from the BoC API.
- Added comprehensive unit tests in 	ests/test_scraper.py to verify the rate-limiting logic.
- Improved the skip message for better clarity.

Fixes #17